### PR TITLE
Included waitress

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,12 @@ and this project WILL ADHERE (as in, in the future) to [Semantic Versioning](htt
 
   - Corresponding SQL tables (user id, background image color/link (separate table?), profile image link, biography text)
 
+## 1.0.3 - 2021-09-22
+
+### Changed
+
+- Edited setup.py to include waitress
+
 ## 1.0.2 - 2021-09-21
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@ from setuptools import find_packages, setup
 
 setup(
     name='flaskr',
-    version='1.0.0',
+    version='1.0.3',
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     install_requires=[
         'flask',
+        'waitress'
     ],
 )


### PR DESCRIPTION
Heroku always raises a problem, and the logs state:
```bash
2021-09-23T00:41:11.171944+00:00 heroku[web.1]: Starting process with command `waitress-serve --port=58233 'flask:create_app'`
2021-09-23T00:41:12.000000+00:00 app[api]: Build succeeded
2021-09-23T00:41:12.003057+00:00 app[web.1]: bash: waitress-serve: command not found
2021-09-23T00:41:12.125914+00:00 heroku[web.1]: Process exited with status 127
2021-09-23T00:41:12.194654+00:00 heroku[web.1]: State changed from starting to crashed
```
I tried adding waitress to setup.py to fix this. 